### PR TITLE
Implement GiftKeys::from_descriptor_strings and x_only_pub accessors

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,6 @@ enum Commands {
     },
 }
 
-
 fn show_create_requirements() {
     println!("\nTo create a timelocked bitcoin gift, you'll need:");
     println!("1. Giver's Extended Public Key (tpub)");
@@ -61,14 +60,12 @@ fn show_create_requirements() {
 }
 
 fn create_gift(giver_pk: &str, receiver_pk: &str, timelock: u32) -> Result<(), Error> {
-    
-    // Create gift keys from tpubs
+    // Create gift keys from descriptors
     let gift_keys = GiftKeys::from_descriptor_strings(giver_pk, receiver_pk)?;
 
     if timelock < 1 {
         return Err(Error::KeyError("Timelock must be greater than 0".to_string()));
     }
-
 
     // Create script with timelock
     let script = GiftScript::new(timelock);
@@ -82,7 +79,6 @@ fn create_gift(giver_pk: &str, receiver_pk: &str, timelock: u32) -> Result<(), E
     // Create address from script
     let address = bitcoin::Address::from_script(&taproot_script, bitcoin::Network::Regtest)
         .map_err(|e| Error::ScriptError(format!("Failed to create address: {}", e)))?;
-
     
     // Get control block information
     let merkle_root = spend_info.merkle_root();
@@ -102,7 +98,7 @@ fn create_gift(giver_pk: &str, receiver_pk: &str, timelock: u32) -> Result<(), E
     // Key information
     println!("\nSpending Information:");
     println!("---------------------");
-    println!("Internal Key (MuSig2 Aggregate): {}", gift_keys.giver_x_only_pub()?);
+    println!("Internal Key (Giver): {}", gift_keys.giver_x_only_pub()?);
     println!("Receiver Public Key: {}", gift_keys.receiver_x_only_pub()?);
     
     // Script information

--- a/src/script/mod.rs
+++ b/src/script/mod.rs
@@ -1,5 +1,5 @@
 use bitcoin::{ScriptBuf, XOnlyPublicKey};
-use bitcoin::secp256k1::{PublicKey, Secp256k1};
+use bitcoin::secp256k1::Secp256k1;
 use bitcoin::taproot::TaprootBuilder;
 use bitcoin::Address;
 use bitcoin::Network;
@@ -28,28 +28,28 @@ impl GiftScript {
     }
 
     pub fn create_taproot_tree(&self, keys: &GiftKeys) -> Result<(ScriptBuf, bitcoin::taproot::TaprootSpendInfo), Error> {
-    // Get the aggregated MuSig2 key for the keypath
-    let internal_key = keys.giver_x_only_pub()?;
-    
-    // Get the receiver's x-only public key and unwrap the Result
-    let receiver_key = keys.receiver_x_only_pub()?;
-    
-    // Create the timelock script for the script path
-    let timelock_script = self.create_timelock_script(receiver_key)?;
+        // Get the giver's key for the keypath
+        let internal_key = keys.giver_x_only_pub()?;
+        
+        // Get the receiver's x-only public key
+        let receiver_key = keys.receiver_x_only_pub()?;
+        
+        // Create the timelock script for the script path
+        let timelock_script = self.create_timelock_script(receiver_key)?;
 
-    // Initialize secp context
-    let secp = Secp256k1::new();
+        // Initialize secp context
+        let secp = Secp256k1::new();
 
-    // Build taproot tree with our script
-    let spend_info = TaprootBuilder::new()
-        .add_leaf(0, timelock_script.clone())
-        .map_err(|e| Error::ScriptError(format!("Failed to add script to tree: {:?}", e)))?
-        .finalize(&secp, internal_key)
-        .map_err(|e| Error::ScriptError(format!("Failed to finalize taproot: {:?}", e)))?;
+        // Build taproot tree with our script
+        let spend_info = TaprootBuilder::new()
+            .add_leaf(0, timelock_script.clone())
+            .map_err(|e| Error::ScriptError(format!("Failed to add script to tree: {:?}", e)))?
+            .finalize(&secp, internal_key)
+            .map_err(|e| Error::ScriptError(format!("Failed to finalize taproot: {:?}", e)))?;
 
-    // Convert to P2TR address
-    let address = Address::p2tr(&secp, internal_key, spend_info.merkle_root(), Network::Regtest);
-    
-    Ok((address.script_pubkey(), spend_info))
-}
+        // Convert to P2TR address
+        let address = Address::p2tr(&secp, internal_key, spend_info.merkle_root(), Network::Regtest);
+        
+        Ok((address.script_pubkey(), spend_info))
+    }
 }


### PR DESCRIPTION
This commit adds:
1. GiftKeys::from_descriptor_strings to create GiftKeys from descriptor strings
2. Methods to access x-only public keys: giver_x_only_pub and receiver_x_only_pub
3. Updated script/mod.rs to use x-only public keys
4. Updated main.rs with improved key handling and better output
5. Added README.md with usage documentation and important note about descriptor formats

The changes improve key handling by using DescriptorPublicKey directly rather than extracting them from script outputs, and clarify that descriptor strings should not include the tr() wrapper when used with the CLI tools.